### PR TITLE
OpenMP proof of concept

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -7,3 +7,7 @@ compute_scale <- function(mat, centering) {
     .Call('_BiocSingular_compute_scale', PACKAGE = 'BiocSingular', mat, centering)
 }
 
+set_omp_threads <- function(nthreads) {
+    .Call('_BiocSingular_set_omp_threads', PACKAGE = 'BiocSingular', nthreads)
+}
+

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -16,9 +16,20 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// set_omp_threads
+Rcpp::IntegerVector set_omp_threads(Rcpp::IntegerVector nthreads);
+RcppExport SEXP _BiocSingular_set_omp_threads(SEXP nthreadsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type nthreads(nthreadsSEXP);
+    rcpp_result_gen = Rcpp::wrap(set_omp_threads(nthreads));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_BiocSingular_compute_scale", (DL_FUNC) &_BiocSingular_compute_scale, 2},
+    {"_BiocSingular_set_omp_threads", (DL_FUNC) &_BiocSingular_set_omp_threads, 1},
     {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
Tagging @mtmorgan as per our previous discussions on Slack.

Typical usage:

```r
library(BiocSingular)
library(Matrix)
mat <- rsparsematrix(2e4, 1e5, density=0.01)
BiocSingular:::set_omp_threads(2L)
system.time(X <- BiocSingular:::compute_scale(mat, NULL))
```

A couple of points:

- Uses `set_omp_threads()` (stolen from _ShortRead_) to control the number of OpenMP threads globally. This would be an excellent candidate for inclusion as an option in a `BiocParallelParam` object somewhere, such that entry into a `bp*apply` loop also sets the OpenMP threads. This would centralize control of OpenMP parallelization into the _BiocParallel_ framework, and free developers from having to define their own OpenMP-related arguments in every parallelized functions.
- _beachmat_'s getters are maintained in serial sections. This is because they may involve calls back out to the R API, and it would probably be dicey to assume that R is happy with multiple threads calling it at the same time. As a result, this code saturates quite quickly with increasing cores as the loops are bottlenecked at the data loading step. Oh well.