### PR TITLE
fix logic in compute_center_and_scale()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocSingular
-Version: 1.27.0
+Version: 1.27.1
 Date: 2025-10-23
 Title: Singular Value Decomposition for Bioconductor Packages
 Authors@R: c(person("Aaron", "Lun", role=c("aut", "cre", "cph"),

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,6 +2,10 @@
 \title{BiocSingular News}
 \encoding{UTF-8}
 
+\section{Version 1.28.0}{\itemize{
+\item Bugfix for \code{center=TRUE} and \code{scale=TRUE} when there are fewer than two rows.
+}}
+
 \section{Version 1.22.0}{\itemize{
 \item Bugfix for \code{scale=TRUE} with zero-variance rows.
 }}

--- a/src/compute_scale.cpp
+++ b/src/compute_scale.cpp
@@ -49,13 +49,8 @@ Rcpp::List compute_center_and_scale(Rcpp::RObject mat, int nthreads) {
         if (NR == 0) {
             std::fill(center.begin(), center.end(), R_NaReal);
         } else {
-            if (ptr->prefer_rows()) {
-                auto iptr = ptr->dense_row()->fetch(0, cptr);
-                tatami::copy_n(iptr, NC, cptr);
-            } else {
-                auto iptr = ptr->dense_column()->fetch(0, cptr);
-                tatami::copy_n(iptr, NR, cptr);
-            }
+            auto iptr = ptr->dense_row()->fetch(0, cptr);
+            tatami::copy_n(iptr, NC, cptr);
         }
         std::fill(scale.begin(), scale.end(), R_NaReal);
         return Rcpp::List::create(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -60,6 +60,44 @@ test_that("center and scale calculations work correctly", {
     }
 })
 
+test_that("center and scale calculations work for edge cases", {
+    for (it in 1:4) {
+        if (it==1L) {
+            A <- matrix(runif(10), 1, 10)
+        } else if (it==2L) {
+            A <- t(DelayedArray(matrix(rnorm(10), 10, 1))) # dense, prefers rows
+        }
+
+        out <- BiocSingular:::.compute_center_and_scale(A, center=TRUE, scale=TRUE, nthreads=1)
+        expect_identical(out$center, A[1,])
+        expect_identical(out$scale, rep(NA_real_, 10))
+
+        out <- BiocSingular:::.compute_center_and_scale(A, center=TRUE, scale=FALSE, nthreads=1)
+        expect_identical(out$center, A[1,])
+
+        out <- BiocSingular:::.compute_center_and_scale(A, center=FALSE, scale=TRUE, nthreads=1)
+        expect_identical(out$scale, rep(NA_real_, 10))
+    }
+
+    for (it in 1:4) {
+        if (it==1L) {
+            A <- matrix(runif(0), 0, 10)
+        } else if (it==2L) {
+            A <- t(DelayedArray(matrix(rnorm(0), 10, 0))) # dense, prefers rows
+        }
+
+        out <- BiocSingular:::.compute_center_and_scale(A, center=TRUE, scale=TRUE, nthreads=1)
+        expect_identical(out$center, rep(NA_real_, 10))
+        expect_identical(out$scale, rep(NA_real_, 10))
+
+        out <- BiocSingular:::.compute_center_and_scale(A, center=TRUE, scale=FALSE, nthreads=1)
+        expect_identical(out$center, rep(NA_real_, 10))
+
+        out <- BiocSingular:::.compute_center_and_scale(A, center=FALSE, scale=TRUE, nthreads=1)
+        expect_identical(out$scale, rep(NA_real_, 10))
+    }
+})
+
 test_that("standardize_matrix works correctly", {
     A <- matrix(runif(2000), 50, 40)
 


### PR DESCRIPTION
Seems there's a very minor bug in `src/compute_scale.cpp`, in `compute_center_and_scale()`.


Case: NR <= 1, NR != 0, `ptr->prefer_rows()` is not true, then the following code is run in the existing:

```
auto iptr = ptr->dense_column()->fetch(0, cptr);
tatami::copy_n(iptr, NR, cptr); // only NR=1 element written to center, the last NC-1 are ignored
```

Proposed fix: Fetch the first row and write into `center`---without the `prefer_rows()` check. Number of elements written = number of columns, `NC`, rather than NR=1.

